### PR TITLE
One possible strategy for support enum as a parameter

### DIFF
--- a/coreschema/schemas.py
+++ b/coreschema/schemas.py
@@ -30,6 +30,11 @@ def push_index(errors, key):
 class Schema(object):
     errors = {}
 
+    def __new__(cls, *args, **kwargs):
+        if 'enum' in kwargs:
+            return Enum(**kwargs)
+        return object.__new__(cls)
+
     def __init__(self, title='', description='', default=None):
         self.title = title
         self.description = description

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -45,3 +45,8 @@ def test_format_uri():
     schema = String(format='uri')
     assert schema.validate('http://example.com') == []
     assert schema.validate('example.com') == [('Must be a valid uri.', [])]
+
+def test_enum():
+    schema = String(enum=['a', 'b', 'c'])
+    assert schema.validate('a') == []
+    assert schema.validate('d') == [("Must be one of ['a', 'b', 'c'].", [])]


### PR DESCRIPTION
This is one possible way to support `enum` as a parameter and fix #11 

I didn't know whether coreschema wants to even store `enum` as a property but it does have an `Enum` schema type. This patches `Schema.__new__` to see if `enum` is passed and will return an `Enum` instance instead.  