### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     install_requires=[
         'jinja2'
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
Helps pip decide what version of the library to install.

https://packaging.python.org/tutorials/distributing-packages/#python-requires

> If your project only runs on certain Python versions, setting the
> python_requires argument to the appropriate PEP 440 version specifier
> string will prevent pip from installing the project on other Python
> versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440)
> for the Python version, used to specify the Requires-Python defined in
> PEP 345.